### PR TITLE
fix: Update bytes crate to fix security vulnerability RUSTSEC-2026-0007

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,9 +248,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"


### PR DESCRIPTION
## Summary
Fixes security vulnerability detected by cargo-audit.

## Security Advisory
- **ID**: RUSTSEC-2026-0007
- **Crate**: bytes
- **Vulnerability**: Integer overflow in `BytesMut::reserve`
- **URL**: https://github.com/advisories/GHSA-434x-w66g-qw3r

## Changes
- Updated `bytes` crate from 1.11.0 to 1.11.1

## Verification
- [x] `cargo build --release` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace --exclude falkorsemantic-module` passes
- [x] `cargo audit` shows no vulnerabilities

## Note
There is still a warning about `proc-macro-error` (RUSTSEC-2024-0370) being unmaintained. This is a transitive dependency from the `json-ld` ecosystem and can only be fixed when upstream maintainers update their dependencies.
 
 **PR Summary by Typo**
------------

#### Overview
This PR addresses a security vulnerability (RUSTSEC-2026-0007) by updating the `bytes` crate dependency to a patched version.

#### Key Changes
- Updated the `bytes` crate from version `1.11.0` to `1.11.1` in `Cargo.lock`.
- Updated the checksum for the `bytes` crate to reflect the new version.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| Rework   | 2 (100.0%)    |
| Total Changes | 2         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>