### PR TITLE
Change license badge to AGPL v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A high-performance Redis module that extends [FalkorDB](https://www.falkordb.com/) with RDF and SPARQL capabilities, bridging the property graph and semantic web worlds.
 
 [![CI](https://github.com/FalkorDB/FalkorSemantic/actions/workflows/ci.yml/badge.svg)](https://github.com/FalkorDB/FalkorSemantic/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-
+[![License: MIT](https://img.shields.io/badge/license-AGPL--v3-blue)](https://opensource.org/licenses/agpl-v3)
+ 
 ## Overview
 
 FalkorSemantic is a Redis module that enables semantic web data processing with FalkorDB. It provides:


### PR DESCRIPTION
Change license badge to AGPL v3
 
 **PR Summary by Typo**
------------

#### Overview
This PR updates the license badge displayed in the `README.md` file.

#### Key Changes
- The license badge in `README.md` has been changed from MIT to AGPL v3.

#### Work Breakdown

| Category | Lines Changed |
|----------|---------------|
| Rework   | 2 (100.0%)    |
| Total Changes | 2         | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated license badge from MIT to AGPLv3 in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->