### PR TITLE
feat: translate SPARQL literal objects as node property access

### DIFF
--- a/mapper/src/query/translator.rs
+++ b/mapper/src/query/translator.rs
@@ -106,8 +106,12 @@ fn literal_to_cypher_value(datatype: &str, lexical: &str) -> String {
     if datatype == XSD_DECIMAL && is_valid_decimal(lexical) {
         return lexical.to_string();
     }
-    if (datatype == XSD_FLOAT || datatype == XSD_DOUBLE) && lexical.parse::<f64>().is_ok() {
-        return lexical.to_string();
+    if datatype == XSD_FLOAT || datatype == XSD_DOUBLE {
+        if let Ok(parsed) = lexical.parse::<f64>() {
+            if parsed.is_finite() {
+                return lexical.to_string();
+            }
+        }
     }
     if datatype == XSD_BOOLEAN {
         let normalized = lexical.trim();
@@ -604,14 +608,14 @@ impl SparqlToCypher {
                 let edge_obj_var = self.next_var("edge");
 
                 // Register dual binding
-                self.var_bindings.borrow_mut().insert(
-                    v.as_str().to_string(),
-                    VarBinding::Dual {
+                self.var_bindings
+                    .borrow_mut()
+                    .entry(v.as_str().to_string())
+                    .or_insert(VarBinding::Dual {
                         subject_var: subj_var.clone(),
                         prop_key: prop_key.clone(),
                         edge_obj_var: edge_obj_var.clone(),
-                    },
-                );
+                    });
 
                 let optional = format!("({subj_var})-[{rel_var}{pred_str}]->({edge_obj_var})");
 
@@ -1604,6 +1608,20 @@ mod tests {
         assert!(
             cypher.query.contains("s.flag = true"),
             "Should emit normalized boolean token, got: {}",
+            cypher.query
+        );
+    }
+
+    #[test]
+    fn test_literal_constant_object_typed_double_non_finite_quoted() {
+        let result = translate(
+            "SELECT ?s WHERE { ?s <http://example.org/score> \"inf\"^^<http://www.w3.org/2001/XMLSchema#double> }",
+        );
+        assert!(result.is_ok(), "Failed: {:?}", result.err());
+        let cypher = result.unwrap();
+        assert!(
+            cypher.query.contains("s.score = 'inf'"),
+            "Non-finite double should stay quoted, got: {}",
             cypher.query
         );
     }


### PR DESCRIPTION
## Summary

- RDF literals are stored as properties on subject nodes (e.g., `foaf:name "Alice"` → `SET s.name = 'Alice'`), but the translator always generated edge patterns expecting separate nodes — causing all literal-object queries to return empty results
- Implements dual-pattern translation: literal constants use property WHERE, variable objects with known predicates get OPTIONAL MATCH edge + property fallback, named nodes / variable predicates keep existing edge behavior
- Adds `VarBinding` tracking so `build_return_clause` generates CASE expressions that prioritize edge nodes and fall back to `toString(subject.property)`

## Example

**SPARQL:** `SELECT ?s ?name WHERE { ?s <foaf:name> ?name }`

**Before (broken):**
```cypher
MATCH (s)-[r_0{predicate: 'http://xmlns.com/foaf/0.1/name'}]->(name)
RETURN ... name ...
```

**After (works):**
```cypher
MATCH (s)
OPTIONAL MATCH (s)-[r_0{predicate: 'http://xmlns.com/foaf/0.1/name'}]->(name_edge)
WHERE (name_edge IS NOT NULL OR s.name IS NOT NULL)
RETURN CASE WHEN name_edge IS NOT NULL THEN {uri: name_edge.uri, value: name_edge.value}
            WHEN s.name IS NOT NULL THEN {value: toString(s.name)}
            ELSE null END AS name
```

## Test plan

- [x] All 89 existing mapper tests pass (no regressions)
- [x] 7 new tests: literal constant, dual pattern, IRI-only edge, mixed patterns, variable predicate, UNION with literals, property key extraction
- [x] `cargo clippy` clean, `cargo fmt` applied
- [ ] Manual verification with FalkorDB using test RDF data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
 
 
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved SPARQL→Cypher translation: better handling of literal property patterns, dual (edge-or-property) patterns, OPTIONAL matches, and UNIONs.

* **Improvements**
  * More accurate variable projection and conditional return expressions to prefer edge or node values as appropriate.
  * Expanded test coverage for literals, dual/edge patterns, optional branches, and unions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
 
 
 
 
 
 **PR Summary by Typo**
------------

#### Overview
This PR enhances the SPARQL to Cypher translator to intelligently handle literal objects, translating them into direct node property access where appropriate. It introduces a "dual pattern" mechanism for variable objects with known predicates, allowing for both edge-based and property-based representation in Cypher.

#### Key Changes
- Implemented `VarBinding` to track how SPARQL variables are bound (Node or Dual).
- Added `predicate_to_property_key` and `literal_to_cypher_value` for converting RDF predicates to Cypher property keys and RDF literals to Cypher values, respectively.
- Modified `translate_triple_pattern` to generate direct property `WHERE` clauses for constant literal objects and "dual patterns" (using `OPTIONAL MATCH` and property fallback) for variable objects with known predicates.
- Updated `build_return_clause` to generate `CASE` expressions for dual-bound variables, prioritizing edge nodes and falling back to node properties.
- Introduced new internal structures (`TripleResult`) and refactored pattern processing to support these new translation strategies.

#### Work Breakdown
| Category | Lines Changed |
|---|---|
| New Work | 508 (91.5%) |
| Churn | 3 (0.5%) |
| Rework | 44 (7.9%) |
| Total Changes | 555 | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>